### PR TITLE
Implement Podinfo with per-environment Values

### DIFF
--- a/bank-projects.cue
+++ b/bank-projects.cue
@@ -231,6 +231,12 @@ BankOfHolos: #BankOfHolos & {
 							component: path: "projects/bank-frontend/components/bank-frontend"
 						}
 						components: (FRONTEND.name): FRONTEND.component
+
+						let PODINFO = BUILDER & {
+							_component: "\(ENV.name)-podinfo"
+							component: path: "projects/bank-frontend/components/podinfo"
+						}
+						components: (PODINFO.name): PODINFO.component
 					}
 				}
 			}

--- a/deploy/clusters/workload/projects/nonprod-bank-web/components/dev-podinfo/dev-podinfo.gen.yaml
+++ b/deploy/clusters/workload/projects/nonprod-bank-web/components/dev-podinfo/dev-podinfo.gen.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.holos.run/cluster.name: workload
+    app.holos.run/component.name: dev-podinfo
+    app.holos.run/environment.name: dev
+    app.holos.run/project.name: nonprod-bank-web
+    app.holos.run/stack.name: bank-of-holos
+    app.holos.run/team.name: frontend
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: podinfo
+    app.kubernetes.io/version: 6.6.2
+    argocd.argoproj.io/instance: nonprod-bank-web-dev-podinfo
+    helm.sh/chart: podinfo-6.6.2
+  name: podinfo
+  namespace: dev-bank-frontend
+spec:
+  ports:
+  - name: http
+    port: 9898
+    protocol: TCP
+    targetPort: http
+  - name: grpc
+    port: 9999
+    protocol: TCP
+    targetPort: grpc
+  selector:
+    app.kubernetes.io/name: podinfo
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.holos.run/cluster.name: workload
+    app.holos.run/component.name: dev-podinfo
+    app.holos.run/environment.name: dev
+    app.holos.run/project.name: nonprod-bank-web
+    app.holos.run/stack.name: bank-of-holos
+    app.holos.run/team.name: frontend
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: podinfo
+    app.kubernetes.io/version: 6.6.2
+    argocd.argoproj.io/instance: nonprod-bank-web-dev-podinfo
+    helm.sh/chart: podinfo-6.6.2
+  name: podinfo
+  namespace: dev-bank-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: podinfo
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9898"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: podinfo
+    spec:
+      containers:
+      - command:
+        - ./podinfo
+        - --port=9898
+        - --cert-path=/data/cert
+        - --port-metrics=9797
+        - --grpc-port=9999
+        - --grpc-service-name=podinfo
+        - --level=info
+        - --random-delay=false
+        - --random-error=false
+        env:
+        - name: PODINFO_UI_COLOR
+          value: '#34577c'
+        image: ghcr.io/stefanprodan/podinfo:6.6.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/healthz
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: podinfo
+        ports:
+        - containerPort: 9898
+          name: http
+          protocol: TCP
+        - containerPort: 9797
+          name: http-metrics
+          protocol: TCP
+        - containerPort: 9999
+          name: grpc
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/readyz
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 1m
+            memory: 16Mi
+        volumeMounts:
+        - mountPath: /data
+          name: data
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir: {}
+        name: data

--- a/deploy/clusters/workload/projects/nonprod-bank-web/components/stage-podinfo/stage-podinfo.gen.yaml
+++ b/deploy/clusters/workload/projects/nonprod-bank-web/components/stage-podinfo/stage-podinfo.gen.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.holos.run/cluster.name: workload
+    app.holos.run/component.name: stage-podinfo
+    app.holos.run/environment.name: stage
+    app.holos.run/project.name: nonprod-bank-web
+    app.holos.run/stack.name: bank-of-holos
+    app.holos.run/team.name: frontend
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: podinfo
+    app.kubernetes.io/version: 6.6.2
+    argocd.argoproj.io/instance: nonprod-bank-web-stage-podinfo
+    helm.sh/chart: podinfo-6.6.2
+  name: podinfo
+  namespace: stage-bank-frontend
+spec:
+  ports:
+  - name: http
+    port: 9898
+    protocol: TCP
+    targetPort: http
+  - name: grpc
+    port: 9999
+    protocol: TCP
+    targetPort: grpc
+  selector:
+    app.kubernetes.io/name: podinfo
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.holos.run/cluster.name: workload
+    app.holos.run/component.name: stage-podinfo
+    app.holos.run/environment.name: stage
+    app.holos.run/project.name: nonprod-bank-web
+    app.holos.run/stack.name: bank-of-holos
+    app.holos.run/team.name: frontend
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: podinfo
+    app.kubernetes.io/version: 6.6.2
+    argocd.argoproj.io/instance: nonprod-bank-web-stage-podinfo
+    helm.sh/chart: podinfo-6.6.2
+  name: podinfo
+  namespace: stage-bank-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: podinfo
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9898"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: podinfo
+    spec:
+      containers:
+      - command:
+        - ./podinfo
+        - --port=9898
+        - --cert-path=/data/cert
+        - --port-metrics=9797
+        - --grpc-port=9999
+        - --grpc-service-name=podinfo
+        - --level=info
+        - --random-delay=false
+        - --random-error=false
+        env:
+        - name: PODINFO_UI_COLOR
+          value: '#34577c'
+        image: ghcr.io/stefanprodan/podinfo:6.6.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/healthz
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: podinfo
+        ports:
+        - containerPort: 9898
+          name: http
+          protocol: TCP
+        - containerPort: 9797
+          name: http-metrics
+          protocol: TCP
+        - containerPort: 9999
+          name: grpc
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/readyz
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 1m
+            memory: 16Mi
+        volumeMounts:
+        - mountPath: /data
+          name: data
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir: {}
+        name: data

--- a/deploy/clusters/workload/projects/nonprod-bank-web/components/test-podinfo/test-podinfo.gen.yaml
+++ b/deploy/clusters/workload/projects/nonprod-bank-web/components/test-podinfo/test-podinfo.gen.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.holos.run/cluster.name: workload
+    app.holos.run/component.name: test-podinfo
+    app.holos.run/environment.name: test
+    app.holos.run/project.name: nonprod-bank-web
+    app.holos.run/stack.name: bank-of-holos
+    app.holos.run/team.name: frontend
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: podinfo
+    app.kubernetes.io/version: 6.6.2
+    argocd.argoproj.io/instance: nonprod-bank-web-test-podinfo
+    helm.sh/chart: podinfo-6.6.2
+  name: podinfo
+  namespace: test-bank-frontend
+spec:
+  ports:
+  - name: http
+    port: 9898
+    protocol: TCP
+    targetPort: http
+  - name: grpc
+    port: 9999
+    protocol: TCP
+    targetPort: grpc
+  selector:
+    app.kubernetes.io/name: podinfo
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.holos.run/cluster.name: workload
+    app.holos.run/component.name: test-podinfo
+    app.holos.run/environment.name: test
+    app.holos.run/project.name: nonprod-bank-web
+    app.holos.run/stack.name: bank-of-holos
+    app.holos.run/team.name: frontend
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: podinfo
+    app.kubernetes.io/version: 6.6.2
+    argocd.argoproj.io/instance: nonprod-bank-web-test-podinfo
+    helm.sh/chart: podinfo-6.6.2
+  name: podinfo
+  namespace: test-bank-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: podinfo
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9898"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: podinfo
+    spec:
+      containers:
+      - command:
+        - ./podinfo
+        - --port=9898
+        - --cert-path=/data/cert
+        - --port-metrics=9797
+        - --grpc-port=9999
+        - --grpc-service-name=podinfo
+        - --level=info
+        - --random-delay=false
+        - --random-error=false
+        env:
+        - name: PODINFO_UI_COLOR
+          value: '#34577c'
+        image: ghcr.io/stefanprodan/podinfo:6.6.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/healthz
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: podinfo
+        ports:
+        - containerPort: 9898
+          name: http
+          protocol: TCP
+        - containerPort: 9797
+          name: http-metrics
+          protocol: TCP
+        - containerPort: 9999
+          name: grpc
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/readyz
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 1m
+            memory: 16Mi
+        volumeMounts:
+        - mountPath: /data
+          name: data
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir: {}
+        name: data

--- a/deploy/clusters/workload/projects/nonprod-bank-web/gitops/dev-podinfo.application.gen.yaml
+++ b/deploy/clusters/workload/projects/nonprod-bank-web/gitops/dev-podinfo.application.gen.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    labels:
+        app.holos.run/cluster.name: workload
+        app.holos.run/component.name: dev-podinfo
+        app.holos.run/environment.name: dev
+        app.holos.run/project.name: nonprod-bank-web
+        app.holos.run/stack.name: bank-of-holos
+        app.holos.run/team.name: frontend
+    name: nonprod-bank-web-dev-podinfo
+    namespace: argocd
+spec:
+    destination:
+        server: https://kubernetes.default.svc
+    project: nonprod-bank-web
+    source:
+        path: deploy/clusters/workload/projects/nonprod-bank-web/components/dev-podinfo
+        repoURL: https://github.com/holos-run/bank-of-holos.git
+        targetRevision: main

--- a/deploy/clusters/workload/projects/nonprod-bank-web/gitops/stage-podinfo.application.gen.yaml
+++ b/deploy/clusters/workload/projects/nonprod-bank-web/gitops/stage-podinfo.application.gen.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    labels:
+        app.holos.run/cluster.name: workload
+        app.holos.run/component.name: stage-podinfo
+        app.holos.run/environment.name: stage
+        app.holos.run/project.name: nonprod-bank-web
+        app.holos.run/stack.name: bank-of-holos
+        app.holos.run/team.name: frontend
+    name: nonprod-bank-web-stage-podinfo
+    namespace: argocd
+spec:
+    destination:
+        server: https://kubernetes.default.svc
+    project: nonprod-bank-web
+    source:
+        path: deploy/clusters/workload/projects/nonprod-bank-web/components/stage-podinfo
+        repoURL: https://github.com/holos-run/bank-of-holos.git
+        targetRevision: main

--- a/deploy/clusters/workload/projects/nonprod-bank-web/gitops/test-podinfo.application.gen.yaml
+++ b/deploy/clusters/workload/projects/nonprod-bank-web/gitops/test-podinfo.application.gen.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    labels:
+        app.holos.run/cluster.name: workload
+        app.holos.run/component.name: test-podinfo
+        app.holos.run/environment.name: test
+        app.holos.run/project.name: nonprod-bank-web
+        app.holos.run/stack.name: bank-of-holos
+        app.holos.run/team.name: frontend
+    name: nonprod-bank-web-test-podinfo
+    namespace: argocd
+spec:
+    destination:
+        server: https://kubernetes.default.svc
+    project: nonprod-bank-web
+    source:
+        path: deploy/clusters/workload/projects/nonprod-bank-web/components/test-podinfo
+        repoURL: https://github.com/holos-run/bank-of-holos.git
+        targetRevision: main

--- a/deploy/clusters/workload/projects/prod-bank-web/components/prod-east-podinfo/prod-east-podinfo.gen.yaml
+++ b/deploy/clusters/workload/projects/prod-bank-web/components/prod-east-podinfo/prod-east-podinfo.gen.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.holos.run/cluster.name: workload
+    app.holos.run/component.name: prod-east-podinfo
+    app.holos.run/environment.name: prod-east
+    app.holos.run/project.name: prod-bank-web
+    app.holos.run/stack.name: bank-of-holos
+    app.holos.run/team.name: frontend
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: podinfo
+    app.kubernetes.io/version: 6.6.2
+    argocd.argoproj.io/instance: prod-bank-web-prod-east-podinfo
+    helm.sh/chart: podinfo-6.6.2
+  name: podinfo
+  namespace: prod-east-bank-frontend
+spec:
+  ports:
+  - name: http
+    port: 9898
+    protocol: TCP
+    targetPort: http
+  - name: grpc
+    port: 9999
+    protocol: TCP
+    targetPort: grpc
+  selector:
+    app.kubernetes.io/name: podinfo
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.holos.run/cluster.name: workload
+    app.holos.run/component.name: prod-east-podinfo
+    app.holos.run/environment.name: prod-east
+    app.holos.run/project.name: prod-bank-web
+    app.holos.run/stack.name: bank-of-holos
+    app.holos.run/team.name: frontend
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: podinfo
+    app.kubernetes.io/version: 6.6.2
+    argocd.argoproj.io/instance: prod-bank-web-prod-east-podinfo
+    helm.sh/chart: podinfo-6.6.2
+  name: podinfo
+  namespace: prod-east-bank-frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: podinfo
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9898"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: podinfo
+    spec:
+      containers:
+      - command:
+        - ./podinfo
+        - --port=9898
+        - --cert-path=/data/cert
+        - --port-metrics=9797
+        - --grpc-port=9999
+        - --grpc-service-name=podinfo
+        - --level=info
+        - --random-delay=false
+        - --random-error=false
+        env:
+        - name: PODINFO_UI_COLOR
+          value: '#34577c'
+        image: ghcr.io/stefanprodan/podinfo:6.6.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/healthz
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: podinfo
+        ports:
+        - containerPort: 9898
+          name: http
+          protocol: TCP
+        - containerPort: 9797
+          name: http-metrics
+          protocol: TCP
+        - containerPort: 9999
+          name: grpc
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/readyz
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 1m
+            memory: 16Mi
+        volumeMounts:
+        - mountPath: /data
+          name: data
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir: {}
+        name: data

--- a/deploy/clusters/workload/projects/prod-bank-web/components/prod-west-podinfo/prod-west-podinfo.gen.yaml
+++ b/deploy/clusters/workload/projects/prod-bank-web/components/prod-west-podinfo/prod-west-podinfo.gen.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.holos.run/cluster.name: workload
+    app.holos.run/component.name: prod-west-podinfo
+    app.holos.run/environment.name: prod-west
+    app.holos.run/project.name: prod-bank-web
+    app.holos.run/stack.name: bank-of-holos
+    app.holos.run/team.name: frontend
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: podinfo
+    app.kubernetes.io/version: 6.6.2
+    argocd.argoproj.io/instance: prod-bank-web-prod-west-podinfo
+    helm.sh/chart: podinfo-6.6.2
+  name: podinfo
+  namespace: prod-west-bank-frontend
+spec:
+  ports:
+  - name: http
+    port: 9898
+    protocol: TCP
+    targetPort: http
+  - name: grpc
+    port: 9999
+    protocol: TCP
+    targetPort: grpc
+  selector:
+    app.kubernetes.io/name: podinfo
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.holos.run/cluster.name: workload
+    app.holos.run/component.name: prod-west-podinfo
+    app.holos.run/environment.name: prod-west
+    app.holos.run/project.name: prod-bank-web
+    app.holos.run/stack.name: bank-of-holos
+    app.holos.run/team.name: frontend
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: podinfo
+    app.kubernetes.io/version: 6.6.2
+    argocd.argoproj.io/instance: prod-bank-web-prod-west-podinfo
+    helm.sh/chart: podinfo-6.6.2
+  name: podinfo
+  namespace: prod-west-bank-frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: podinfo
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9898"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: podinfo
+    spec:
+      containers:
+      - command:
+        - ./podinfo
+        - --port=9898
+        - --cert-path=/data/cert
+        - --port-metrics=9797
+        - --grpc-port=9999
+        - --grpc-service-name=podinfo
+        - --level=info
+        - --random-delay=false
+        - --random-error=false
+        env:
+        - name: PODINFO_UI_COLOR
+          value: '#34577c'
+        image: ghcr.io/stefanprodan/podinfo:6.6.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/healthz
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: podinfo
+        ports:
+        - containerPort: 9898
+          name: http
+          protocol: TCP
+        - containerPort: 9797
+          name: http-metrics
+          protocol: TCP
+        - containerPort: 9999
+          name: grpc
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/readyz
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 1m
+            memory: 16Mi
+        volumeMounts:
+        - mountPath: /data
+          name: data
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir: {}
+        name: data

--- a/deploy/clusters/workload/projects/prod-bank-web/gitops/prod-east-podinfo.application.gen.yaml
+++ b/deploy/clusters/workload/projects/prod-bank-web/gitops/prod-east-podinfo.application.gen.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    labels:
+        app.holos.run/cluster.name: workload
+        app.holos.run/component.name: prod-east-podinfo
+        app.holos.run/environment.name: prod-east
+        app.holos.run/project.name: prod-bank-web
+        app.holos.run/stack.name: bank-of-holos
+        app.holos.run/team.name: frontend
+    name: prod-bank-web-prod-east-podinfo
+    namespace: argocd
+spec:
+    destination:
+        server: https://kubernetes.default.svc
+    project: prod-bank-web
+    source:
+        path: deploy/clusters/workload/projects/prod-bank-web/components/prod-east-podinfo
+        repoURL: https://github.com/holos-run/bank-of-holos.git
+        targetRevision: main

--- a/deploy/clusters/workload/projects/prod-bank-web/gitops/prod-west-podinfo.application.gen.yaml
+++ b/deploy/clusters/workload/projects/prod-bank-web/gitops/prod-west-podinfo.application.gen.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    labels:
+        app.holos.run/cluster.name: workload
+        app.holos.run/component.name: prod-west-podinfo
+        app.holos.run/environment.name: prod-west
+        app.holos.run/project.name: prod-bank-web
+        app.holos.run/stack.name: bank-of-holos
+        app.holos.run/team.name: frontend
+    name: prod-bank-web-prod-west-podinfo
+    namespace: argocd
+spec:
+    destination:
+        server: https://kubernetes.default.svc
+    project: prod-bank-web
+    source:
+        path: deploy/clusters/workload/projects/prod-bank-web/components/prod-west-podinfo
+        repoURL: https://github.com/holos-run/bank-of-holos.git
+        targetRevision: main

--- a/projects/bank-frontend/components/podinfo/podinfo.cue
+++ b/projects/bank-frontend/components/podinfo/podinfo.cue
@@ -1,0 +1,33 @@
+package holos
+
+holos: Podinfo.BuildPlan
+
+// Access Namespace and Tier from BankOfHolos field defined in the root of the repository.
+_namespace: BankOfHolos.configuration.environments[EnvironmentName].frontend.namespace
+_tier: BankOfHolos.Environments[EnvironmentName].tier
+
+Podinfo: #Helm & {
+    Namespace: _namespace
+    // Ensure metadata.namespace is added to all resources with kustomize.
+    KustomizeConfig: Kustomization: namespace: _namespace
+    Chart: {
+        name: "podinfo"
+        version: "6.6.2"
+        repository: {
+            name: "podinfo"
+            url: "https://stefanprodan.github.io/podinfo"
+        }
+    }
+
+    // Schema to specify chart values based on the cluster's tier (e.g. prod or nonprod)
+    #TierValues: [TIER=string]: replicaCount: int & >=0
+
+    // Use 3 replicas in prod, and 1 in all nonprod environments
+    let TIERVALUES = #TierValues & {
+        nonprod: replicaCount: 1
+        prod: replicaCount: 3
+    }
+
+    // Provide all tier-specific Helm chart values via Chart.Values
+    Values: TIERVALUES[_tier]
+}

--- a/projects/bank-frontend/components/podinfo/podinfo.values.gen.cue
+++ b/projects/bank-frontend/components/podinfo/podinfo.values.gen.cue
@@ -1,0 +1,211 @@
+package holos
+
+// Imported from Helm chart version 6.6.2 with the following command:
+//     holos cue import \
+//       --package holos \
+//       --path 'Podinfo: Values:' \
+//       --outfile podinfo.values.gen.cue \
+//       projects/bank-frontend/components/podinfo/vendor/6.6.2/podinfo/values.yaml
+
+Podinfo: Values: {
+	// Default values for podinfo.
+	replicaCount: int
+	logLevel:     "info"
+	host:         //0.0.0.0
+			null
+	backend:      //http://backend-podinfo:9898/echo
+			null
+	backends: []
+	image: {
+		repository: "ghcr.io/stefanprodan/podinfo"
+		tag:        "6.6.2"
+		pullPolicy: "IfNotPresent"
+	}
+	ui: {
+		color:   "#34577c"
+		message: ""
+		logo:    ""
+	}
+
+	// failure conditions
+	faults: {
+		delay:       false
+		error:       false
+		unhealthy:   false
+		unready:     false
+		testFail:    false
+		testTimeout: false
+	}
+
+	// Kubernetes Service settings
+	service: {
+		enabled: true
+		annotations: {}
+		type:         "ClusterIP"
+		metricsPort:  9797
+		httpPort:     9898
+		externalPort: 9898
+		grpcPort:     9999
+		grpcService:  "podinfo"
+		nodePort:     31198
+		// the port used to bind the http port to the host
+		// NOTE: requires privileged container with NET_BIND_SERVICE capability -- this is useful for testing
+		// in local clusters such as kind without port forwarding
+		hostPort: null
+	}
+
+	// enable h2c protocol (non-TLS version of HTTP/2)
+	h2c: {
+		enabled: false
+	}
+
+	// config file settings
+	config: {
+		// config file path
+		path: ""
+		// config file name
+		name: ""
+	}
+
+	// Additional command line arguments to pass to podinfo container
+	extraArgs: []
+
+	// enable tls on the podinfo service
+	tls: {
+		enabled: false
+		// the name of the secret used to mount the certificate key pair
+		secretName: null
+		// the path where the certificate key pair will be mounted
+		certPath: "/data/cert"
+		// the port used to host the tls endpoint on the service
+		port: 9899
+		// the port used to bind the tls port to the host
+		// NOTE: requires privileged container with NET_BIND_SERVICE capability -- this is useful for testing
+		// in local clusters such as kind without port forwarding
+		hostPort: null
+	}
+
+	// create a certificate manager certificate (cert-manager required)
+	certificate: {
+		create: false
+		// the issuer used to issue the certificate
+		issuerRef: {
+			kind: "ClusterIssuer"
+			name: "self-signed"
+		}
+		// the hostname / subject alternative names for the certificate
+		dnsNames: ["podinfo"]
+	}
+
+	// metrics-server add-on required
+	hpa: {
+		enabled:     false
+		maxReplicas: 10
+		// average total CPU usage per pod (1-100)
+		cpu: null
+		// average memory usage per pod (100Mi-1Gi)
+		memory: null
+		// average http requests per second per pod (k8s-prometheus-adapter)
+		requests: null
+	}
+
+	// Redis address in the format tcp://<host>:<port>
+	cache: ""
+	// Redis deployment
+	redis: {
+		enabled:    false
+		repository: "redis"
+		tag:        "7.0.7"
+	}
+	serviceAccount: {
+		// Specifies whether a service account should be created
+		enabled: false
+		// The name of the service account to use.
+		// If not set and create is true, a name is generated using the fullname template
+		name: null
+		// List of image pull secrets if pulling from private registries
+		imagePullSecrets: []
+	}
+
+	// set container security context
+	securityContext: {}
+	ingress: {
+		enabled:   false
+		className: ""
+		additionalLabels: {}
+		annotations: {}
+		// kubernetes.io/ingress.class: nginx
+		// kubernetes.io/tls-acme: "true"
+		hosts: [{
+			host: "podinfo.local"
+			paths: [{
+				path:     "/"
+				pathType: "ImplementationSpecific"
+			}]
+		}]
+		//  - secretName: chart-example-tls
+		//    hosts:
+		//      - chart-example.local
+		tls: []
+	}
+	linkerd: profile: enabled: false
+
+	// create Prometheus Operator monitor
+	serviceMonitor: {
+		enabled:  false
+		interval: "15s"
+		additionalLabels: {}
+	}
+	resources: {
+		limits: null
+		requests: {
+			cpu:    "1m"
+			memory: "16Mi"
+		}
+	}
+
+	// Extra environment variables for the podinfo container
+	// Example on how to configure extraEnvs
+	//  - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+	//    value: "http://otel:4317"
+	//  - name: MULTIPLE_VALUES
+	//    value: TEST
+	extraEnvs: []
+	nodeSelector: {}
+	tolerations: []
+	affinity: {}
+	podAnnotations: {}
+
+	// https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+	topologySpreadConstraints: []
+
+	// Disruption budget will be configured only when the replicaCount is greater than 1
+	//  maxUnavailable: 1
+	podDisruptionBudget: {}
+
+	// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	probes: {
+		readiness: {
+			initialDelaySeconds: 1
+			timeoutSeconds:      5
+			failureThreshold:    3
+			successThreshold:    1
+			periodSeconds:       10
+		}
+		liveness: {
+			initialDelaySeconds: 1
+			timeoutSeconds:      5
+			failureThreshold:    3
+			successThreshold:    1
+			periodSeconds:       10
+		}
+		startup: {
+			enable:              false
+			initialDelaySeconds: 10
+			timeoutSeconds:      5
+			failureThreshold:    20
+			successThreshold:    1
+			periodSeconds:       10
+		}
+	}
+}


### PR DESCRIPTION
PROBLEM:

We've added code to the repo demonstrating a way to handle environments,
but we haven't yet tackled the problem of a component with imported
default values that has a different value on a per-environment basis.

SOLUTION:

Add a `podinfo` component that uses the correct environment namespace,
then update the configuration to ensure there are three replicas in
`prod` and a single replica in other environments.

OUTCOME:

A very basic example showing different Helm chart values on
a per-environment basis.